### PR TITLE
Add quiescence search to negamax

### DIFF
--- a/Forklift.Core/Search.cs
+++ b/Forklift.Core/Search.cs
@@ -73,11 +73,6 @@ namespace Forklift.Core
             Board.Move? preferredMove = null,
             CancellationToken cancellationToken = default)
         {
-            if (depth == 0)
-            {
-                return new SearchNodeResult(null, Evaluator.EvaluateForSideToMove(board), true);
-            }
-
             if (cancellationToken.IsCancellationRequested)
             {
                 return new SearchNodeResult(null, Evaluator.EvaluateForSideToMove(board), false);
@@ -86,14 +81,14 @@ namespace Forklift.Core
             if (depth == 0)
             {
                 int quiescenceScore = Quiescence(board, alpha, beta, cancellationToken);
-                return (null, quiescenceScore);
+                return new SearchNodeResult(null, quiescenceScore, true);
             }
 
             var legalMoves = board.GenerateLegal();
 
             if (legalMoves.Length == 0)
             {
-                return new SearchNodeResult(null, Evaluator.EvaluateForSideToMove(board), true);
+                return new SearchNodeResult(null, EvaluateTerminal(board), true);
             }
 
             bool didPvMoveOrdering = false;


### PR DESCRIPTION
## Summary

This pull request introduces a quiescence search to the chess engine's search algorithm, improving how positions are evaluated at leaf nodes to reduce the horizon effect and make tactical evaluations more accurate. It also refactors terminal node evaluation for clarity and correctness, and adds a constant for mate scores.

**Search algorithm improvements:**

* Added a `Quiescence` search method to extend evaluation at leaf nodes, ensuring positions are evaluated in a tactically stable state rather than at arbitrary depth cutoffs. Now, when the search reaches depth zero, it calls `Quiescence` instead of evaluating directly. [[1]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99L75-R91) [[2]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99R175-R294)
* Introduced a `MateScore` constant to represent checkmate evaluation values, making mate detection and scoring explicit and consistent.

**Terminal and cancellation handling:**

* Refactored terminal node evaluation into a new `EvaluateTerminal` method for clarity and to handle checkmate and stalemate situations more accurately. [[1]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99L75-R91) [[2]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99R175-R294)
* Improved cancellation handling in both the main search and quiescence search to ensure early exits are handled safely and correctly. [[1]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99L75-R91) [[2]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99R175-R294)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915abb3e1c08327ba94091eaaa3cf0e)