### PR TITLE
Add mate score handling

### DIFF
--- a/Forklift.ConsoleClient/UciLogger.cs
+++ b/Forklift.ConsoleClient/UciLogger.cs
@@ -42,8 +42,12 @@ static class UciLogger
         public override string ToString()
         {
             var nps = Summary.NodesSearched / Math.Max(Elapsed.TotalMilliseconds / 1000.0, 1);
-            var pvString = Summary.PrincipalVariation.Any() ? $" pv {string.Join(' ', Summary.PrincipalVariation.Select(m => m?.ToUCIString() ?? "0000"))}" : string.Empty;
-            return $"info depth {Summary.CompletedDepth} score cp {Summary.BestScore} nodes {Summary.NodesSearched} nps {nps:F0} time {Elapsed.TotalMilliseconds:F0}{pvString}";
+            var score = Summary.TryGetMateInFromRootScore(out int mateIn)
+                ? $"mate {mateIn}"
+                : $"cp {Summary.BestScore}";
+            var nonNullPv = string.Join(" ", Summary.PrincipalVariation.TakeWhile(m => m.HasValue).Select(m => m!.Value.ToUCIString()));
+            var pvString = Summary.PrincipalVariation.Any() ? $" pv {nonNullPv}" : string.Empty;
+            return $"info depth {Summary.CompletedDepth} score {score} nodes {Summary.NodesSearched} nps {nps:F0} time {Elapsed.TotalMilliseconds:F0}{pvString}";
         }
     };
 

--- a/Forklift.Core/Evaluator.cs
+++ b/Forklift.Core/Evaluator.cs
@@ -13,6 +13,8 @@ namespace Forklift.Core
 
         public const int MaxEvaluationScore = 1 << 18; // ±262144
         public const int MinEvaluationScore = -MaxEvaluationScore;
+        public const int MateValue = MaxEvaluationScore * 2;
+        public const int MateScoreThreshold = MateValue - 512;
         private const int PhaseMax = 24;
 
         // Piece-square tables from PeSTO (Rofchade)
@@ -285,5 +287,39 @@ namespace Forklift.Core
                 Piece.PieceType.Queen => 4,
                 _ => 0 // Pawns and Kings do not affect game phase in PeSTO
             };
+
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int NormalizeScoreForStorage(int score, int ply)
+        {
+            if (score >= MateScoreThreshold)
+            {
+                return score + ply;
+            }
+
+            if (score <= -MateScoreThreshold)
+            {
+                return score - ply;
+            }
+
+            return score;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int RestoreScoreFromStorage(int score, int ply)
+        {
+            if (score >= MateScoreThreshold)
+            {
+                return score - ply;
+            }
+
+            if (score <= -MateScoreThreshold)
+            {
+                return score + ply;
+            }
+
+            return score;
+        }
     }
 }

--- a/Forklift.Core/TranspositionTable.cs
+++ b/Forklift.Core/TranspositionTable.cs
@@ -16,12 +16,6 @@ public sealed class TranspositionTable
         Beta
     }
 
-    // MateValue must always be larger than any evaluation score returned by
-    // Evaluator.EvaluateForSideToMove so mate scores cannot be confused with
-    // regular evaluation values.
-    internal const int MateValue = Evaluator.MaxEvaluationScore * 2;
-    internal const int MateScoreThreshold = MateValue - 512;
-
     private readonly Entry[] _entries;
     private readonly int _mask;
 
@@ -77,7 +71,7 @@ public sealed class TranspositionTable
         if (entry.ZobristKey != zobristKey)
             return ProbeResult.Miss;
 
-        int score = RestoreScoreFromStorage(entry.Score, ply);
+        int score = Evaluator.RestoreScoreFromStorage(entry.Score, ply);
         return new ProbeResult(entry.NodeType, score, entry.BestMove, entry.Depth);
     }
 
@@ -118,40 +112,8 @@ public sealed class TranspositionTable
 
         entry.ZobristKey = zobristKey;
         entry.Depth = depth;
-        entry.Score = NormalizeScoreForStorage(score, ply);
+        entry.Score = Evaluator.NormalizeScoreForStorage(score, ply);
         entry.NodeType = nodeType;
         entry.BestMove = bestMove;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int NormalizeScoreForStorage(int score, int ply)
-    {
-        if (score >= MateScoreThreshold)
-        {
-            return score + ply;
-        }
-
-        if (score <= -MateScoreThreshold)
-        {
-            return score - ply;
-        }
-
-        return score;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int RestoreScoreFromStorage(int score, int ply)
-    {
-        if (score >= MateScoreThreshold)
-        {
-            return score - ply;
-        }
-
-        if (score <= -MateScoreThreshold)
-        {
-            return score + ply;
-        }
-
-        return score;
     }
 }


### PR DESCRIPTION
## Summary

This pull request refactors the handling of mate scores in the evaluation and search logic, centralizing mate score constants and normalization logic in the `Evaluator` class. It also improves the reporting of mate scores in UCI output by providing "mate in N" information. The most significant changes are grouped below:

**Mate Score Handling and Constants:**

* Moved mate score constants (`MateValue`, `MateScoreThreshold`) from `TranspositionTable` to `Evaluator` and updated all references accordingly. This ensures a single source of truth for mate score logic. [[1]](diffhunk://#diff-08679976f2e23ea9b1500eee853b148256d65dc8e74b20b956488489f9d5abd4R16-R17) [[2]](diffhunk://#diff-375230b6a7809b686c2e65e1372a44aeab23a80d66501aec34c2af2e4aed3ba0L19-L24) [[3]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99L17) [[4]](diffhunk://#diff-0eade7dc6f19c40ab1559341fd1ebc8ef90dc3e0c99337dc47886bdd03d77c99L551-R577)

* Centralized the normalization and restoration of mate scores for storage and retrieval in the transposition table by moving `NormalizeScoreForStorage` and `RestoreScoreFromStorage` methods to `Evaluator`. All usages updated to reference the new location. [[1]](diffhunk://#diff-08679976f2e23ea9b1500eee853b148256d65dc8e74b20b956488489f9d5abd4R290-R323) [[2]](diffhunk://#diff-375230b6a7809b686c2e65e1372a44aeab23a80d66501aec34c2af2e4aed3ba0L80-R74) [[3]](diffhunk://#diff-375230b6a7809b686c2e65e1372a44aeab23a80d66501aec34c2af2e4aed3ba0L121-L156)

**UCI Output Improvements:**

* Enhanced the `SearchSummary` record with a `TryGetMateInFromRootScore` method to extract "mate in N" information from mate scores.

* Updated the UCI logger (`UciLogger.cs`) to use the new mate detection, reporting mate scores as "mate N" instead of centipawn values when appropriate. Also improved principal variation reporting by filtering out null moves.